### PR TITLE
Added scan for variables False

### DIFF
--- a/docassemble/ssioverpaymentwaiver/data/questions/ssi_overpayment_waiver.yml
+++ b/docassemble/ssioverpaymentwaiver/data/questions/ssi_overpayment_waiver.yml
@@ -27,6 +27,7 @@ sections:
   - Finishing up
 ---
 mandatory: True
+scan for variables: False
 code: |
   nav.set_section('Getting started')
   intro_screen


### PR DESCRIPTION
It was seeking the definition of "jobs" from the wrong block.